### PR TITLE
use argparse to parse cli arguments

### DIFF
--- a/make_pkgbuild.py
+++ b/make_pkgbuild.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import re
 import os
 import sys
@@ -8,21 +9,29 @@ import datetime
 from sys import stderr
 from datetime import date
 
-usage = "Usage: make_pkgbuild.py <pkgbuild template> <rust makefile>"
 release_number_regex = r"CFG_RELEASE_NUM[ ]*=[ ]*(?P<value>.*)"
 release_label_regex = r"CFG_RELEASE_LABEL[ ]*=[ ]*(?P<value>.*)"
 
-def main():
-	# Parse command-line args
-	if len(sys.argv) != 3:
-		print(usage, file=stderr)
-		sys.exit(1)
+def build_args():
+    parser = argparse.ArgumentParser(
+	    description='PKGBUILD generator for Rust nightly')
+    parser.add_argument('template',
+			type=str,
+			help='path to PKGBUILD template',
+			metavar='pkgbuild_template',
+			)
+    parser.add_argument('makefile',
+			type=str,
+			help='path to Rust makefile',
+			metavar='rust_makefile',
+			)
+    return parser
 
-	template_file = sys.argv[1]
-	rust_makefile = sys.argv[2]
+def main():
+	args = build_args().parse_args()
 
 	# Extract the version information from the Rust makefile
-	with open(rust_makefile, "r") as f:
+	with open(args.makefile, "r") as f:
 		rust_mk_contents = f.readlines()
 
 	r1 = re.compile(release_number_regex)
@@ -49,7 +58,7 @@ def main():
 	version = version_number + version_label + "_" + datestring
 
 	# Write the PKGBUILD to stdout
-	with open(template_file, "r") as f:
+	with open(args.template, "r") as f:
 		pkgbuild = f.read()
 
 	pkgbuild = pkgbuild.replace("{VERSION}", version)


### PR DESCRIPTION
Using Python's argparse makes the script's help text better: it's more
detailed and gives the user descriptions for their input. It gives you
consistent internal naming, while letting you change the UI, and it's a
standardized feature across Python packages.

Example usage:

``` bash
rust-nightly-archlinux$ ./make_pkgbuild.py
usage: make_pkgbuild.py [-h] pkgbuild_template rust_makefile
make_pkgbuild.py: error: the following arguments are required: pkgbuild_template, rust_makefile
rust-nightly-archlinux$ ./make_pkgbuild.py -h
usage: make_pkgbuild.py [-h] pkgbuild_template rust_makefile

PKGBUILD generator for Rust nightly

positional arguments:
  pkgbuild_template  path to PKGBUILD template
  rust_makefile      path to Rust makefile

optional arguments:
  -h, --help         show this help message and exit
```
