### PR TITLE
Avoid man symlink dir on install

### DIFF
--- a/templates/rust.pkgbuild
+++ b/templates/rust.pkgbuild
@@ -19,10 +19,11 @@ options=(staticlibs !strip)
 
 package() {
     local INSTALL_DIR=/usr/local
+    local MAN_DIR=/usr/local/man
 
     # Rust
     cd rust-nightly-${CARCH}-unknown-linux-gnu
-    ./install.sh --prefix=${pkgdir}${INSTALL_DIR}
+    ./install.sh --prefix=${pkgdir}${INSTALL_DIR} --mandir=${pkgdir}${MAN_DIR}
 
     # Docs
     local DOC_DIR=${pkgdir}${INSTALL_DIR}/share/doc/rust/html


### PR DESCRIPTION
Instead of installing using /usr/local/share/man's symlink, install
directly to /usr/local/man. This fixes a build error introduced with
pacman 4.2.
