### PR TITLE
Remove manifest file referencing $pkgdir

### DIFF
--- a/templates/cargo.pkgbuild
+++ b/templates/cargo.pkgbuild
@@ -18,4 +18,5 @@ options=(staticlibs !strip)
 package() {
     cd cargo-nightly-${CARCH}-unknown-linux-gnu
     ./install.sh --prefix=$pkgdir/usr
+    rm "$pkgdir/usr/lib/cargo/manifest"
 }


### PR DESCRIPTION
This removes the makepkg warning:

`WARNING: Package contains reference to $pkgdir`

This trick is also used in the `community/rust` package.
