### PR TITLE
Remove manifest file referencing $pkgdir

### DIFF
--- a/templates/cargo.pkgbuild
+++ b/templates/cargo.pkgbuild
@@ -18,6 +18,7 @@ options=(staticlibs !strip)
 package() {
     cd cargo-nightly-${CARCH}-unknown-linux-gnu
     ./install.sh --prefix=$pkgdir/usr
-    # This will need updating imminently.
-    # rm -f "$pkgdir/usr/lib/cargo/cargo-manifest"
+
+    # remove manifest file referencing $pkgdir
+    rm -f "${pkgdir}/usr/lib/rustlib/manifest-cargo"
 }

--- a/templates/rust.pkgbuild
+++ b/templates/rust.pkgbuild
@@ -42,4 +42,7 @@ package() {
     # Dynamic library configuration (no LD_LIBRARY_PATH required).
     mkdir -p "${pkgdir}/etc/ld.so.conf.d"
     install -m 644 "${srcdir}/rust-nightly.conf" "${pkgdir}/etc/ld.so.conf.d/rust-nightly.conf"
+
+    # remove manifest file referencing $pkgdir
+    rm -f "${pkgdir}/usr/local/lib/rustlib/manifest-rustc"
 }


### PR DESCRIPTION
Same as we did for the cargo package, but this time for the rust package.

I have also included the changed path for the cargo package.
